### PR TITLE
I moved the `ToastProvider` and `ConfigProvider` to `_app.tsx` to ens…

### DIFF
--- a/WebApp_Playground/src/pages/_app.tsx
+++ b/WebApp_Playground/src/pages/_app.tsx
@@ -3,11 +3,17 @@ import "@livekit/components-styles/components/participant";
 import "@/styles/home.css";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { ToastProvider } from "@/components/toast/ToasterProvider";
+import { ConfigProvider } from "@/hooks/useConfig";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <CloudProvider>
-      <Component {...pageProps} />
+      <ToastProvider>
+        <ConfigProvider>
+          <Component {...pageProps} />
+        </ConfigProvider>
+      </ToastProvider>
     </CloudProvider>
   );
 }

--- a/WebApp_Playground/src/pages/index.tsx
+++ b/WebApp_Playground/src/pages/index.tsx
@@ -6,8 +6,7 @@ import {
 } from "@livekit/components-react";
 import Head from "next/head";
 import { useCallback, useState, useEffect } from "react";
-import { ToastProvider, useToast } from "@/components/toast/ToasterProvider";
-import { ConfigProvider } from "@/hooks/useConfig";
+import { useToast } from "@/components/toast/ToasterProvider";
 import { RoomEvent, ConnectionState } from "livekit-client";
 
 const agents = {
@@ -62,21 +61,17 @@ export default function Home() {
   const token = "devtoken";
 
   return (
-    <ToastProvider>
-      <ConfigProvider>
-        <LiveKitRoom
-          serverUrl={wsUrl}
-          token={token}
-          connect={shouldConnect}
-          onError={(e) => {
-            setToastMessage({ message: e.message, type: "error" });
-            console.error(e);
-          }}
-        >
-          <HomePage onConnect={handleConnect} />
-        </LiveKitRoom>
-      </ConfigProvider>
-    </ToastProvider>
+    <LiveKitRoom
+      serverUrl={wsUrl}
+      token={token}
+      connect={shouldConnect}
+      onError={(e) => {
+        setToastMessage({ message: e.message, type: "error" });
+        console.error(e);
+      }}
+    >
+      <HomePage onConnect={handleConnect} />
+    </LiveKitRoom>
   );
 }
 


### PR DESCRIPTION
…ure they wrap your entire application.

I then removed the providers from `index.tsx`.

This change fixes the "useToast must be used within a ToastProvider" error and ensures that your application renders correctly.