### PR TITLE
Fix: Resolve Next.js warnings and LiveKit connection issue

### DIFF
--- a/PLAYGROUND/src/pages/_document.tsx
+++ b/PLAYGROUND/src/pages/_document.tsx
@@ -1,12 +1,19 @@
 import { Html, Head, Main, NextScript } from "next/document";
+import Script from "next/script";
 
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+        <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+      </Head>
       <body>
         <Main />
         <NextScript />
+        <Script src="https://unpkg.com/livekit-client/dist/livekit-client.umd.js" strategy="beforeInteractive"></Script>
       </body>
     </Html>
   );

--- a/PLAYGROUND/src/pages/index.tsx
+++ b/PLAYGROUND/src/pages/index.tsx
@@ -255,11 +255,6 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Progrify | AI-Powered Digital Mastery</title>
         <meta name="description" content="Master the universe of AI with Progrify's specialized agents for coding, product building, prompt engineering, and sales mastery." />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
-        <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-        <script src="https://unpkg.com/livekit-client/dist/livekit-client.umd.js" async></script>
         <style>{`
             :root {
               --primary: #7c3aed;


### PR DESCRIPTION
This commit addresses two issues:
1.  **Next.js Warnings:** Moves the external stylesheets and the LiveKit client script from the `<Head>` component in `pages/index.tsx` to `pages/_document.tsx`. This follows Next.js best practices and resolves the warnings about including stylesheets and scripts directly in the page's head.
2.  **LiveKit Connection:** Creates a `.env.local` file in the `PLAYGROUND` directory to store the `NEXT_PUBLIC_LIVEKIT_URL` environment variable. This ensures that the frontend connects to the same LiveKit instance as me, fixing the "Disconnected" issue.