### PR TITLE
Fix: Use runtime config for environment variables

### DIFF
--- a/PLAYGROUND/next.config.js
+++ b/PLAYGROUND/next.config.js
@@ -4,6 +4,13 @@ const withNextPluginPreval = createNextPluginPreval();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  serverRuntimeConfig: {
+    livekitApiKey: process.env.LIVEKIT_API_KEY,
+    livekitApiSecret: process.env.LIVEKIT_API_SECRET,
+  },
+  publicRuntimeConfig: {
+    livekitUrl: process.env.NEXT_PUBLIC_LIVEKIT_URL,
+  },
 };
 
 module.exports = withNextPluginPreval(nextConfig);

--- a/PLAYGROUND/src/pages/api/token.ts
+++ b/PLAYGROUND/src/pages/api/token.ts
@@ -1,13 +1,15 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { generateRandomAlphanumeric } from "@/lib/util";
+import getConfig from 'next/config';
 
 import { AccessToken } from "livekit-server-sdk";
 import { RoomAgentDispatch, RoomConfiguration } from "@livekit/protocol";
 import type { AccessTokenOptions, VideoGrant } from "livekit-server-sdk";
 import { TokenResult } from "../../lib/types";
 
-const apiKey = process.env.LIVEKIT_API_KEY;
-const apiSecret = process.env.LIVEKIT_API_SECRET;
+const { serverRuntimeConfig } = getConfig();
+const apiKey = serverRuntimeConfig.livekitApiKey;
+const apiSecret = serverRuntimeConfig.livekitApiSecret;
 
 const createToken = (
   userInfo: AccessTokenOptions,

--- a/PLAYGROUND/src/pages/index.tsx
+++ b/PLAYGROUND/src/pages/index.tsx
@@ -1,6 +1,9 @@
 import Head from "next/head";
 import { useEffect } from 'react';
+import getConfig from 'next/config';
 import { Room, RoomEvent, LocalAudioTrack, RemoteParticipant, RemoteTrackPublication, RemoteTrack } from 'livekit-client';
+
+const { publicRuntimeConfig } = getConfig();
 
 export default function Home() {
   useEffect(() => {
@@ -91,7 +94,7 @@ export default function Home() {
           dynacast: true,
         });
 
-        const livekitUrl = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'ws://localhost:7880';
+        const livekitUrl = publicRuntimeConfig.livekitUrl || 'ws://localhost:7880';
 
         await room.connect(livekitUrl, accessToken);
 


### PR DESCRIPTION
This commit refactors the application to use Next.js's runtime configuration for managing environment variables, which is a more robust solution than relying on `.env.local` alone in this context.

Changes include:
- Modified `next.config.js` to expose `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, and `NEXT_PUBLIC_LIVEKIT_URL` through `serverRuntimeConfig` and `publicRuntimeConfig`.
- Updated `pages/api/token.ts` to get the LiveKit API key and secret from `serverRuntimeConfig`.
- Updated `pages/index.tsx` to get the LiveKit URL from `publicRuntimeConfig`.

This should resolve the connection issues by ensuring that both the server-side and client-side parts of the application have access to the necessary environment variables.